### PR TITLE
Add some logic for Pizza Tower compat

### DIFF
--- a/OpenGM/Rendering/SpriteManager.cs
+++ b/OpenGM/Rendering/SpriteManager.cs
@@ -71,6 +71,11 @@ public static class SpriteManager
 
     public static void DrawSpriteExt(int name, double index, double x, double y, double xscale, double yscale, double rot, int blend, double alpha)
     {
+        if (index < 0) 
+        {
+            DebugLog.LogWarning($"Tried to draw sprite {name} with index {index}.");
+            return;
+        }
         var sprite = GetSpritePage(name, index);
         var origin = GetSpriteOrigin(name);
 

--- a/OpenGM/VirtualMachine/BuiltInFunctions/DataStructuresFunctions.cs
+++ b/OpenGM/VirtualMachine/BuiltInFunctions/DataStructuresFunctions.cs
@@ -68,7 +68,32 @@ namespace OpenGM.VirtualMachine.BuiltInFunctions
 		// ds_list_insert
 		// ds_list_replace
 		// ds_list_delete
-		// ds_list_find_index
+
+		[GMLFunction("ds_list_find_index")]
+		public static object? ds_list_find_index(params object?[] args)
+		{
+			var id = args[0].Conv<int>();
+			var value = args[1];
+
+			if (!_dsListDict.ContainsKey(id))
+			{
+				return -1;
+			}
+
+			if (value is null) 
+			{
+				return -1;
+			}
+
+			var list = _dsListDict[id];
+
+			if (id >= list.Count)
+			{
+				return -1;
+			}
+
+			return list.IndexOf(value);
+		}
 
 		[GMLFunction("ds_list_find_value")]
 		public static object? ds_list_find_value(params object?[] args)

--- a/OpenGM/VirtualMachine/BuiltInFunctions/GamepadFunctions.cs
+++ b/OpenGM/VirtualMachine/BuiltInFunctions/GamepadFunctions.cs
@@ -1,4 +1,6 @@
-﻿namespace OpenGM.VirtualMachine.BuiltInFunctions
+﻿using OpenGM.IO;
+
+namespace OpenGM.VirtualMachine.BuiltInFunctions
 {
     public static class GamepadFunctions
     {
@@ -22,7 +24,14 @@
 		// gamepad_get_button_threshold
 		// gamepad_set_button_threshold
 		// gamepad_get_axis_deadzone
-		// gamepad_set_axis_deadzone
+
+		[GMLFunction("gamepad_set_axis_deadzone")]
+		public static object? gamepad_set_axis_deadzone(object?[] args)
+		{
+			DebugLog.LogWarning("gamepad_set_axis_deadzone not implemented.");
+			return null;
+		}
+
 		// gamepad_button_count
 
 		[GMLFunction("gamepad_button_check")]

--- a/OpenGM/VirtualMachine/BuiltInFunctions/GraphicFunctions.cs
+++ b/OpenGM/VirtualMachine/BuiltInFunctions/GraphicFunctions.cs
@@ -43,6 +43,14 @@ namespace OpenGM.VirtualMachine.BuiltInFunctions
 		// display_get_timing_method
 		// display_set_sleep_margin
 		// display_get_sleep_margin
+
+		[GMLFunction("display_set_gui_size")]
+		public static object? display_set_gui_size(object?[] args)
+		{
+			DebugLog.LogWarning("display_set_gui_size not implemented.");
+			return null;
+		}
+
 		// window_set_visible
 		// window_get_visible
 
@@ -1443,6 +1451,16 @@ namespace OpenGM.VirtualMachine.BuiltInFunctions
 		}
 
 		// surface_copy_part
+		
+		[GMLFunction("application_surface_draw_enable")]
+		public static object? application_surface_draw_enable(object?[] args)
+		{
+			var enabled = args[0].Conv<bool>();
+
+			DebugLog.LogWarning("application_surface_draw_enable not implemented");
+
+			return null;
+		}
 
 		// skeleton stuff
 	}

--- a/OpenGM/VirtualMachine/BuiltInFunctions/LayerFunctions.cs
+++ b/OpenGM/VirtualMachine/BuiltInFunctions/LayerFunctions.cs
@@ -372,7 +372,27 @@ namespace OpenGM.VirtualMachine.BuiltInFunctions
 
 		// layer_is_draw_depth_forced
 		// layer_get_forced_depth
-		// layer_background_get_id
+
+		[GMLFunction("layer_background_get_id")]
+		public static object? layer_background_get_id(object?[] args)
+		{
+			var layer_id = args[0].Conv<int>();
+
+			if (!RoomManager.CurrentRoom.Layers.TryGetValue(layer_id, out var layer))
+			{
+				return -1;
+			}
+
+			foreach (var element in layer.ElementsToDraw)
+			{
+				if (element is GMBackground back)
+				{
+					return back.Element.Id;
+				}
+			}
+
+			return -1;
+		}
 
 		[GMLFunction("layer_background_exists")]
 		public static object? layer_background_exists(object?[] args)
@@ -592,7 +612,27 @@ namespace OpenGM.VirtualMachine.BuiltInFunctions
 			return null;
 		}
 
-		// layer_background_index
+
+		[GMLFunction("layer_background_index")]
+		public static object? layer_background_index(object?[] args)
+		{
+			var background_element_id = args[0].Conv<int>();
+			var index = args[0].Conv<int>();
+
+			foreach (var layer in RoomManager.CurrentRoom.Layers)
+			{
+				foreach (var element in layer.Value.ElementsToDraw)
+				{
+					if (element is GMBackground back && back.Element.Id == background_element_id)
+					{
+						back.Element.Index = index;
+					}
+				}
+			}
+
+			return null;
+		}
+
 		// layer_background_speed
 		// layer_background_sprite
 		// layer_background_change
@@ -678,9 +718,38 @@ namespace OpenGM.VirtualMachine.BuiltInFunctions
 			return null;
 		}
 
-		// layer_sprite_change
+		[GMLFunction("layer_sprite_change")]
+		public static object? layer_sprite_change(object?[] args)
+		{
+			var element_id = args[0].Conv<int>();
+			var sprite_id = args[0].Conv<int>();
+
+			DebugLog.LogWarning("layer_sprite_change not implemented.");
+			return null;
+		}
+
 		// layer_sprite_index
-		// layer_sprite_speed
+
+		[GMLFunction("layer_sprite_speed")]
+		public static object? layer_sprite_speed(object?[] args)
+		{
+			var element_id = args[0].Conv<int>();
+			var speed = args[0].Conv<double>();
+
+			foreach (var layer in RoomManager.CurrentRoom.Layers)
+			{
+				foreach (var element in layer.Value.ElementsToDraw)
+				{
+					if (element is GMSprite sprite && sprite.Element.Id == element_id)
+					{
+						sprite.AnimationSpeed = speed;
+					}
+				}
+			}
+
+			return null;
+		}
+
 		// layer_sprite_xscale
 		// layer_sprite_yscale
 		// layer_sprite_angle
@@ -721,6 +790,27 @@ namespace OpenGM.VirtualMachine.BuiltInFunctions
 					{
 						return sprite.FrameIndex;
 					}
+				}
+			}
+
+			return -1;
+		}
+
+		[GMLFunction("layer_sprite_get_id")]
+		public static object? layer_sprite_get_id(object?[] args)
+		{
+			var layer_id = args[0].Conv<int>();
+
+			if (!RoomManager.CurrentRoom.Layers.TryGetValue(layer_id, out var layer))
+			{
+				return -1;
+			}
+
+			foreach (var element in layer.ElementsToDraw)
+			{
+				if (element is GMSprite sprite)
+				{
+					return sprite.Element.Id;
 				}
 			}
 

--- a/OpenGM/VirtualMachine/BuiltInFunctions/MathFunctions.cs
+++ b/OpenGM/VirtualMachine/BuiltInFunctions/MathFunctions.cs
@@ -818,7 +818,23 @@ public static class MathFunctions
 		return ret;
 	}
 
-	// string_letters
+	[GMLFunction("string_letters")]
+	public static object string_letters(object?[] args)
+	{
+		var str = args[0].Conv<string>();
+
+		var result = "";
+
+		foreach (var c in str)
+		{
+			if (char.IsAsciiLetter(c))
+			{
+				result += c;
+			}
+		}
+
+		return result;
+	}
 
 	[GMLFunction("string_digits")]
 	public static object string_digits(object?[] args)

--- a/OpenGM/VirtualMachine/BuiltInFunctions/SoundFunctions.cs
+++ b/OpenGM/VirtualMachine/BuiltInFunctions/SoundFunctions.cs
@@ -166,7 +166,12 @@ namespace OpenGM.VirtualMachine.BuiltInFunctions
 			}
 		}
 
-		// audio_is_paused
+		[GMLFunction("audio_is_paused")]
+		public static object? audio_is_paused(object?[] args)
+		{
+			return !(bool?)audio_is_playing(args);
+		}
+
 		// audio_exists
 		// audio_system_is_available
 		// audio_sound_is_playable


### PR DESCRIPTION
This PR adds (or stubs out) a number of functions which earlier demos of Pizza Tower rely on, namely the SAGE 2019 demo. With this patch set, it's now possible to go past the title screen and enter a level.

I'm not 100% sure whether these have the exact behavior that they do in the official runners, so discretion advised.