### PR TITLE
More work for Pizza Tower

### DIFF
--- a/OpenGM/Entry.cs
+++ b/OpenGM/Entry.cs
@@ -15,18 +15,52 @@ internal class Entry
 
 	private static CustomWindow window = null!;
 
-	public static string[] LaunchParameters = new string[0];
+	public static string[] LaunchParameters = [];
 	public static string DataWinFolder = "";
 
 	static void Main(string[] args)
 	{
+		var passedArgs = ProcessArgs(args);
+
 		// only has to be ran once, even across game_changes
 		ScriptResolver.InitGMLFunctions();
 
 		var exeLocation = AppDomain.CurrentDomain.BaseDirectory;
 		Directory.CreateDirectory(Path.Combine(exeLocation, "game"));
 		var defaultPath = Path.Combine(exeLocation, "game", "data.win");
-		LoadGame(defaultPath, args);
+		LoadGame(defaultPath, [.. passedArgs]);
+	}
+
+	static string[] ProcessArgs(string[] args)
+	{
+		var passedArgs = new List<string>();
+		var endOfOptions = false;
+		foreach (var arg in args)
+		{
+			if (endOfOptions)
+			{
+				passedArgs.Add(arg);
+				continue;
+			}
+
+			switch (arg)
+			{
+				case "--warnings-only":
+					DebugLog.Verbosity = DebugLog.LogType.Warning;
+					break;
+				case "--errors-only":
+					DebugLog.Verbosity = DebugLog.LogType.Error;
+					break;
+				case "--":
+					endOfOptions = true;
+					break;
+				default:
+					passedArgs.Add(arg);
+					break;
+			}
+		}
+
+		return [.. passedArgs];
 	}
 
 	public static DateTime GameLoadTime;

--- a/OpenGM/GamemakerObject.cs
+++ b/OpenGM/GamemakerObject.cs
@@ -467,7 +467,15 @@ public class GamemakerObject : DrawWithDepth, IStackContextSelf
 			return false;
 		}
 
-		if (obj.Marked)
+		// HACK: 
+		//   as a temporary fix for objects which destroy themselves within
+		//   their own destroy events, we mark the object first then allow 
+		//   Destroy and CleanUp events to pass. 
+		//
+		//   `InstanceManager.MarkForDestruction()` prevents these events from
+		//   being called again for destruction if the object is already marked.
+
+		if (obj.Marked && eventType != EventType.Destroy && eventType != EventType.CleanUp)
 		{
 			return false;
 		}

--- a/OpenGM/IO/DebugLog.cs
+++ b/OpenGM/IO/DebugLog.cs
@@ -2,13 +2,25 @@
 
 public static class DebugLog
 {
+    public static LogType Verbosity = LogType.Info;
+
     public static void Log(string message)
     {
+        if (Verbosity < LogType.Info)
+        {
+            return;
+        }
+
         Console.WriteLine(message);
     }
 
     public static void LogWarning(string message)
     {
+        if (Verbosity < LogType.Warning)
+        {
+            return;
+        }
+
         Console.ForegroundColor = ConsoleColor.Yellow;
         Console.WriteLine(message);
         Console.ResetColor();
@@ -16,6 +28,11 @@ public static class DebugLog
 
     public static void LogInfo(string message)
     {
+        if (Verbosity < LogType.Info)
+        {
+            return;
+        }
+
         Console.ForegroundColor = ConsoleColor.Cyan;
         Console.WriteLine(message);
         Console.ResetColor();
@@ -23,8 +40,20 @@ public static class DebugLog
 
     public static void LogError(string message)
     {
+        if (Verbosity < LogType.Error)
+        {
+            return;
+        }
+
         Console.ForegroundColor = ConsoleColor.Red;
         Console.WriteLine(message);
         Console.ResetColor();
+    }
+
+    public enum LogType
+    {
+        Error = 0,
+        Warning = 1,
+        Info = 2
     }
 }

--- a/OpenGM/InstanceManager.cs
+++ b/OpenGM/InstanceManager.cs
@@ -172,13 +172,13 @@ public static class InstanceManager
 
 		if (!obj.Marked && obj.Active)
 		{
+			obj.Marked = true;
 			if (executeEvent)
 			{
 				GamemakerObject.ExecuteEvent(obj, obj.Definition, EventType.Destroy);
 			}
 
 			GamemakerObject.ExecuteEvent(obj, obj.Definition, EventType.CleanUp);
-			obj.Marked = true;
 		}
 	}
 

--- a/OpenGM/Rendering/CustomWindow.cs
+++ b/OpenGM/Rendering/CustomWindow.cs
@@ -306,7 +306,33 @@ public class CustomWindow : GameWindow
                 {
                     // sprite font
 
-                    // TODO: Implement
+                    // returns the index corresponding to the given character,
+                    // or -1 if there isn't one
+                    var idx = textJob.asset.entries
+                        .Select((entry, index) => (entry, index))
+                        .Where(b => b.entry.characterIndex == character)
+                        .Select(b => b.index)
+                        .FirstOrDefault(-1);
+
+                    if (idx == -1)
+                    {
+                        if (character == ' ')
+                        {
+                            xOffset += textJob.asset.Size;
+                        }
+
+                        continue;
+                    }
+
+                    var sprite = SpriteManager.GetSpritePage(textJob.asset.spriteIndex, idx);
+                    Draw(new GMSpriteJob()
+                    {
+                        texture = sprite,
+                        screenPos = textJob.screenPos + (xOffset, 0),
+                        blend = textJob.blend
+                    });
+
+                    xOffset += sprite.TargetSizeX * textJob.scale.X;
                 }
                 else
                 {
@@ -371,10 +397,10 @@ public class CustomWindow : GameWindow
                     GL.End();
                     */
                     VertexManager.Draw(PrimitiveType.TriangleFan, [
-	                    new(new(topLeftX, topLeftY), LerpBetweenColors(c1, c2, stringLeft, stringRight, topLeftX), new(leftX, topY)),
-	                    new(new(topLeftX + glyph.w * textJob.scale.X, topLeftY), LerpBetweenColors(c1, c2, stringLeft, stringRight, topLeftX + glyph.w), new(rightX, topY)),
-	                    new(new(topLeftX + glyph.w * textJob.scale.X, (topLeftY + glyph.h * textJob.scale.Y)), LerpBetweenColors(c4, c3, stringLeft, stringRight, topLeftX + glyph.w), new(rightX, bottomY)),
-	                    new(new(topLeftX, topLeftY + glyph.h * textJob.scale.Y), LerpBetweenColors(c4, c3, stringLeft, stringRight, topLeftX), new(leftX, bottomY)),
+                        new(new(topLeftX, topLeftY), LerpBetweenColors(c1, c2, stringLeft, stringRight, topLeftX), new(leftX, topY)),
+                        new(new(topLeftX + glyph.w * textJob.scale.X, topLeftY), LerpBetweenColors(c1, c2, stringLeft, stringRight, topLeftX + glyph.w), new(rightX, topY)),
+                        new(new(topLeftX + glyph.w * textJob.scale.X, (topLeftY + glyph.h * textJob.scale.Y)), LerpBetweenColors(c4, c3, stringLeft, stringRight, topLeftX + glyph.w), new(rightX, bottomY)),
+                        new(new(topLeftX, topLeftY + glyph.h * textJob.scale.Y), LerpBetweenColors(c4, c3, stringLeft, stringRight, topLeftX), new(leftX, bottomY)),
                     ]);
 
                     GL.BindTexture(TextureTarget.Texture2D, 0);

--- a/OpenGM/RoomManager.cs
+++ b/OpenGM/RoomManager.cs
@@ -207,7 +207,6 @@ public static class RoomManager
 
 				// TODO : if RoomEnd event creates objects, should they be destroyed??
 				GamemakerObject.ExecuteEvent(instance, instance.Definition, EventType.Other, (int)EventSubtypeOther.RoomEnd);
-				GamemakerObject.ExecuteEvent(instance, instance.Definition, EventType.Destroy);
 				GamemakerObject.ExecuteEvent(instance, instance.Definition, EventType.CleanUp);
 
 				instance.Destroy();

--- a/OpenGM/VirtualMachine/BuiltInFunctions/GraphicFunctions.cs
+++ b/OpenGM/VirtualMachine/BuiltInFunctions/GraphicFunctions.cs
@@ -1084,6 +1084,11 @@ namespace OpenGM.VirtualMachine.BuiltInFunctions
 			var x = args[2].Conv<double>();
 			var y = args[3].Conv<double>();
 
+			if (subimg == -1)
+			{
+				subimg = (int)VMExecutor.Self.GMSelf.image_index;
+			}
+
 			SpriteManager.DrawSprite(sprite, subimg, x, y);
 			return null;
 		}
@@ -1100,6 +1105,11 @@ namespace OpenGM.VirtualMachine.BuiltInFunctions
 			var rot = args[6].Conv<double>();
 			var colour = args[7].Conv<int>();
 			var alpha = args[8].Conv<double>();
+
+			if (subimg == -1)
+			{
+				subimg = (int)VMExecutor.Self.GMSelf.image_index;
+			}
 
 			SpriteManager.DrawSpriteExt(sprite, subimg, x, y, xscale, yscale, rot, colour, alpha);
 			return null;
@@ -1119,6 +1129,11 @@ namespace OpenGM.VirtualMachine.BuiltInFunctions
 			var x4 = args[8].Conv<double>();
 			var y4 = args[9].Conv<double>();
 			var alpha = args[10].Conv<double>();
+
+			if (subimg == -1)
+			{
+				subimg = (int)VMExecutor.Self.GMSelf.image_index;
+			}
 
 			var col = 16777215.ABGRToCol4(alpha); // c_white
 			var pageItem = SpriteManager.GetSpritePage(sprite, subimg);
@@ -1158,6 +1173,11 @@ namespace OpenGM.VirtualMachine.BuiltInFunctions
 			var w = args[4].Conv<double>();
 			var h = args[5].Conv<double>();
 
+			if (subimg == -1)
+			{
+				subimg = (int)VMExecutor.Self.GMSelf.image_index;
+			}
+
 			SpriteManager.draw_sprite_stretched(sprite, subimg, x, y, w, h, 0x00FFFFFF, 1);
 			return null;
 		}
@@ -1174,6 +1194,11 @@ namespace OpenGM.VirtualMachine.BuiltInFunctions
 			var colour = args[6].Conv<int>();
 			var alpha = args[7].Conv<double>();
 
+			if (subimg == -1)
+			{
+				subimg = (int)VMExecutor.Self.GMSelf.image_index;
+			}
+
 			SpriteManager.draw_sprite_stretched(sprite, subimg, x, y, w, h, colour, alpha);
 			return null;
 		}
@@ -1189,6 +1214,11 @@ namespace OpenGM.VirtualMachine.BuiltInFunctions
 			var height = args[5].Conv<int>();
 			var x = args[6].Conv<double>();
 			var y = args[7].Conv<double>();
+
+			if (subimg == -1)
+			{
+				subimg = (int)VMExecutor.Self.GMSelf.image_index;
+			}
 
 			SpriteManager.DrawSpritePart(sprite, subimg, left, top, width, height, x, y);
 
@@ -1211,6 +1241,11 @@ namespace OpenGM.VirtualMachine.BuiltInFunctions
 			var colour = args[10].Conv<int>();
 			var alpha = args[11].Conv<double>();
 
+			if (subimg == -1)
+			{
+				subimg = (int)VMExecutor.Self.GMSelf.image_index;
+			}
+
 			SpriteManager.DrawSpritePartExt(sprite, subimg, left, top, width, height, x, y, xscale, yscale, colour, alpha);
 
 			return null;
@@ -1230,6 +1265,11 @@ namespace OpenGM.VirtualMachine.BuiltInFunctions
 			var yscale = args[5].Conv<double>();
 			var colour = args[6].Conv<int>();
 			var alpha = args[7].Conv<double>();
+
+			if (subimg == -1)
+			{
+				subimg = (int)VMExecutor.Self.GMSelf.image_index;
+			}
 
 			var spriteTex = SpriteManager.GetSpritePage(sprite, subimg);
 

--- a/OpenGM/VirtualMachine/BuiltInFunctions/ResourceFunctions.cs
+++ b/OpenGM/VirtualMachine/BuiltInFunctions/ResourceFunctions.cs
@@ -244,12 +244,20 @@ namespace OpenGM.VirtualMachine.BuiltInFunctions
 
 			for (var i = 0; i < string_map.Length; i++)
 			{
+				var page = SpriteManager.GetSpritePage(spriteAssetIndex, i);
 				var fontAssetEntry = new Glyph
 				{
-					characterIndex = string_map[i]
+					characterIndex = string_map[i],
+					x = page.SourcePosX,
+					y = page.SourcePosY,
+					w = page.SourceSizeX,
+					h = page.SourceSizeY,
+					shift = page.TargetPosX
 				};
 
+				// TODO: no way to get the frame index from entriesDict right now
 				newFont.entries.Add(fontAssetEntry);
+				newFont.entriesDict.Add(fontAssetEntry.characterIndex, fontAssetEntry);
 			}
 
 			TextManager.FontAssets.Add(newFont);


### PR DESCRIPTION
- Add an initial, if slightly flawed, sprite font implementation.
- Basic system for command-line switches, complete with log filtering.
- Hack to avoid Pillar John recursively destroying himself and crashing the game.
- Don't call destroy events upon switching rooms, only cleanup events.
- Use the current object's frame index when `subimg` is -1 in the `draw_sprite_...` functions.

This fixes a majority of the visual bugs with SAGE 2019, as well as some gameplay bugs.