### PR TITLE
Refactor how function stubs work

### DIFF
--- a/OpenGM/Entry.cs
+++ b/OpenGM/Entry.cs
@@ -51,6 +51,10 @@ internal class Entry
 				case "--errors-only":
 					DebugLog.Verbosity = DebugLog.LogType.Error;
 					break;
+				case "--verbose":
+				case "-v":
+					DebugLog.Verbosity = DebugLog.LogType.Verbose;
+					break;
 				case "--":
 					endOfOptions = true;
 					break;

--- a/OpenGM/GMLFunctionAttribute.cs
+++ b/OpenGM/GMLFunctionAttribute.cs
@@ -1,8 +1,16 @@
 ﻿namespace OpenGM
 {
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
-    public class GMLFunctionAttribute(string functionName) : Attribute
+    public class GMLFunctionAttribute(string functionName, GMLFunctionFlags functionFlags = 0) : Attribute
     {
 	    public string FunctionName { get; private set; } = functionName;
+	    public GMLFunctionFlags FunctionFlags { get; private set; } = functionFlags;
+    }
+
+    [Flags]
+    public enum GMLFunctionFlags
+    {
+        // write new entries like 1 << 1, 1 << 2...
+        Stub = 1 << 0
     }
 }

--- a/OpenGM/GamemakerObject.cs
+++ b/OpenGM/GamemakerObject.cs
@@ -547,7 +547,7 @@ public class GamemakerObject : DrawWithDepth, IStackContextSelf
 			case EventType.Gesture:
 			case EventType.Mouse:
 			default:
-				DebugLog.LogError($"{eventType} not implemented!");
+				DebugLog.LogError($"Event type {eventType} not implemented.");
 				return false;
 		}
 	}

--- a/OpenGM/IO/DebugLog.cs
+++ b/OpenGM/IO/DebugLog.cs
@@ -50,10 +50,23 @@ public static class DebugLog
         Console.ResetColor();
     }
 
+    public static void LogVerbose(string message)
+    {
+        if (Verbosity < LogType.Verbose)
+        {
+            return;
+        }
+
+        Console.ForegroundColor = ConsoleColor.Magenta;
+        Console.WriteLine(message);
+        Console.ResetColor();
+    }
+
     public enum LogType
     {
         Error = 0,
         Warning = 1,
-        Info = 2
+        Info = 2,
+        Verbose = 3
     }
 }

--- a/OpenGM/IO/ShaderFunctions.cs
+++ b/OpenGM/IO/ShaderFunctions.cs
@@ -9,51 +9,45 @@ namespace OpenGM.IO
 {
 	public static class ShaderFunctions
 	{
-		[GMLFunction("shader_set")]
+		[GMLFunction("shader_set", GMLFunctionFlags.Stub)]
 		public static object? shader_set(object?[] args)
 		{
 			var shaderId = args[0].Conv<int>();
-			DebugLog.LogWarning("shader_set not implemented.");
 			return null;
 		}
 
 		// shader_get_name
 
-		[GMLFunction("shader_reset")]
+		[GMLFunction("shader_reset", GMLFunctionFlags.Stub)]
 		public static object? shader_reset(object?[] args)
 		{
-			DebugLog.LogWarning("shader_reset not implemented.");
 			return null;
 		}
 
-		[GMLFunction("shader_current")]
+		[GMLFunction("shader_current", GMLFunctionFlags.Stub)]
 		public static object? shader_current(object?[] args)
 		{
-			DebugLog.LogWarning("shader_current not implemented.");
 			return null;
 		}
 
-		[GMLFunction("shader_get_uniform")]
+		[GMLFunction("shader_get_uniform", GMLFunctionFlags.Stub)]
 		public static object? shader_get_uniform(object?[] args)
 		{
-			DebugLog.LogWarning("shader_get_uniform not implemented.");
 			return null;
 		}
 
-		[GMLFunction("shader_get_sampler_index")]
+		[GMLFunction("shader_get_sampler_index", GMLFunctionFlags.Stub)]
 		public static object? shader_get_sampler_index(object?[] args)
 		{
-			DebugLog.LogWarning("shader_get_sampler_index not implemented.");
 			return -1;
 		}
 
 		// shader_set_uniform_i
 		// shader_set_uniform_i_array
 
-		[GMLFunction("shader_set_uniform_f")]
+		[GMLFunction("shader_set_uniform_f", GMLFunctionFlags.Stub)]
 		public static object? shader_set_uniform_f(object?[] args)
 		{
-			DebugLog.LogWarning("shader_set_uniform_f not implemented.");
 			return null;
 		}
 
@@ -63,24 +57,21 @@ namespace OpenGM.IO
 		// shader_is_compiled
 		// shaders_are_supported
 
-		[GMLFunction("texture_set_stage")]
+		[GMLFunction("texture_set_stage", GMLFunctionFlags.Stub)]
 		public static object? texture_set_stage(object?[] args)
 		{
-			DebugLog.LogWarning("texture_set_stage not implemented.");
 			return null;
 		}
 
-		[GMLFunction("texture_get_texel_width")]
+		[GMLFunction("texture_get_texel_width", GMLFunctionFlags.Stub)]
 		public static object? texture_get_texel_width(object?[] args)
 		{
-			DebugLog.LogWarning("texture_get_texel_width not implemented.");
 			return 0;
 		}
 
-		[GMLFunction("texture_get_texel_height")]
+		[GMLFunction("texture_get_texel_height", GMLFunctionFlags.Stub)]
 		public static object? texture_get_texel_height(object?[] args)
 		{
-			DebugLog.LogWarning("texture_get_texel_height not implemented.");
 			return 0;
 		}
 	}

--- a/OpenGM/IO/VertexFormatFunctions.cs
+++ b/OpenGM/IO/VertexFormatFunctions.cs
@@ -8,43 +8,38 @@ namespace OpenGM.IO
 {
     public static class VertexFormatFunctions
     {
-		[GMLFunction("vertex_format_begin")]
+		[GMLFunction("vertex_format_begin", GMLFunctionFlags.Stub)]
 	    public static object? vertex_format_begin(object?[] args)
 	    {
-		    DebugLog.LogWarning("vertex_format_begin not implemented.");
 		    return null;
 	    }
 
 		// vertex_format_delete
 
-		[GMLFunction("vertex_format_end")]
+		[GMLFunction("vertex_format_end", GMLFunctionFlags.Stub)]
 		public static object? vertex_format_end(object?[] args)
 		{
-			DebugLog.LogWarning("vertex_format_end not implemented.");
 			return null;
 		}
 
-		[GMLFunction("vertex_format_add_position")]
+		[GMLFunction("vertex_format_add_position", GMLFunctionFlags.Stub)]
 		public static object? vertex_format_add_position(object?[] args)
 		{
-			DebugLog.LogWarning("vertex_format_add_position not implemented.");
 			return null;
 		}
 
 		// vertex_format_add_position_3d
 
-		[GMLFunction("vertex_format_add_color")]
-		[GMLFunction("vertex_format_add_colour")]
+		[GMLFunction("vertex_format_add_color", GMLFunctionFlags.Stub)]
+		[GMLFunction("vertex_format_add_colour", GMLFunctionFlags.Stub)]
 		public static object? vertex_format_add_colour(object?[] args)
 		{
-			DebugLog.LogWarning("vertex_format_add_colour not implemented.");
 			return null;
 		}
 
-		[GMLFunction("vertex_format_add_normal")]
+		[GMLFunction("vertex_format_add_normal", GMLFunctionFlags.Stub)]
 		public static object? vertex_format_add_normal(object?[] args)
 		{
-			DebugLog.LogWarning("vertex_format_add_normal not implemented.");
 			return null;
 		}
 

--- a/OpenGM/Loading/GameConverter.cs
+++ b/OpenGM/Loading/GameConverter.cs
@@ -418,7 +418,7 @@ public static class GameConverter
 					case VMOpcode.PUSHAC:
 						break;
 					default:
-						throw new NotImplementedException($"{enumOperation} not implemented");
+						throw new NotImplementedException($"Opcode {enumOperation} not implemented");
 				}
 
 				if (shouldGetVariableInfo)

--- a/OpenGM/Particles/ParticleManager.cs
+++ b/OpenGM/Particles/ParticleManager.cs
@@ -75,17 +75,17 @@ namespace OpenGM.Particles
 
 		public static void HandleLife(ParticleSystem sys)
 		{
-			DebugLog.LogWarning("HandleLife not implemented");
+			DebugLog.LogWarning("Method HandleLife not implemented.");
 		}
 
 		public static void HandleMotion(ParticleSystem sys)
 		{
-			DebugLog.LogWarning("HandleMotion not implemented");
+			DebugLog.LogWarning("Method HandleMotion not implemented.");
 		}
 
 		public static void HandleShape(ParticleSystem sys)
 		{
-			DebugLog.LogWarning("HandleShape not implemented");
+			DebugLog.LogWarning("Method HandleShape not implemented.");
 		}
 
 		public static void Draw(int ind)
@@ -160,7 +160,7 @@ namespace OpenGM.Particles
 				number = 1;
 			}
 
-			DebugLog.LogWarning("emitterburst not implemented");
+			DebugLog.LogWarning("Method EmitterBurst not implemented.");
 		}
 
 		public static Particle CreateParticle(double x, double y, int particleTypeId)

--- a/OpenGM/VirtualMachine/BuiltInFunctions/3DFunctions.cs
+++ b/OpenGM/VirtualMachine/BuiltInFunctions/3DFunctions.cs
@@ -502,10 +502,9 @@ namespace OpenGM.VirtualMachine.BuiltInFunctions
 
 		// gpu_set_texfilter
 
-		[GMLFunction("gpu_set_texfilter_ext")]
+		[GMLFunction("gpu_set_texfilter_ext", GMLFunctionFlags.Stub)]
 		public static object? gpu_set_texfilter_ext(object?[] args)
 		{
-			DebugLog.LogWarning("gpu_set_texfilter_ext not implemented.");
 			return null;
 		}
 

--- a/OpenGM/VirtualMachine/BuiltInFunctions/GamepadFunctions.cs
+++ b/OpenGM/VirtualMachine/BuiltInFunctions/GamepadFunctions.cs
@@ -25,10 +25,9 @@ namespace OpenGM.VirtualMachine.BuiltInFunctions
 		// gamepad_set_button_threshold
 		// gamepad_get_axis_deadzone
 
-		[GMLFunction("gamepad_set_axis_deadzone")]
+		[GMLFunction("gamepad_set_axis_deadzone", GMLFunctionFlags.Stub)]
 		public static object? gamepad_set_axis_deadzone(object?[] args)
 		{
-			DebugLog.LogWarning("gamepad_set_axis_deadzone not implemented.");
 			return null;
 		}
 

--- a/OpenGM/VirtualMachine/BuiltInFunctions/GraphicFunctions.cs
+++ b/OpenGM/VirtualMachine/BuiltInFunctions/GraphicFunctions.cs
@@ -10,11 +10,10 @@ namespace OpenGM.VirtualMachine.BuiltInFunctions
     public static class GraphicFunctions
     {
 		// not in 2022.500, no idea where in the list it goes
-		[GMLFunction("window_enable_borderless_fullscreen")]
+		[GMLFunction("window_enable_borderless_fullscreen", GMLFunctionFlags.Stub)]
 		public static object? window_enable_borderless_fullscreen(object?[] args)
 		{
 			// todo : implement
-			DebugLog.LogWarning("window_enable_borderless_fullscreen not implemented");
 			return null;
 		}
 
@@ -44,10 +43,9 @@ namespace OpenGM.VirtualMachine.BuiltInFunctions
 		// display_set_sleep_margin
 		// display_get_sleep_margin
 
-		[GMLFunction("display_set_gui_size")]
+		[GMLFunction("display_set_gui_size", GMLFunctionFlags.Stub)]
 		public static object? display_set_gui_size(object?[] args)
 		{
-			DebugLog.LogWarning("display_set_gui_size not implemented.");
 			return null;
 		}
 
@@ -96,19 +94,17 @@ namespace OpenGM.VirtualMachine.BuiltInFunctions
 		// window_set_cursor
 		// window_get_cursor
 
-		[GMLFunction("window_set_color")]
-		[GMLFunction("window_set_colour")]
+		[GMLFunction("window_set_color", GMLFunctionFlags.Stub)]
+		[GMLFunction("window_set_colour", GMLFunctionFlags.Stub)]
 		public static object? window_set_color(object?[] args)
 		{
-			DebugLog.LogWarning("window_set_color not implemented");
 			return null;
 		}
 
-		[GMLFunction("window_get_color")]
-		[GMLFunction("window_get_colour")]
+		[GMLFunction("window_get_color", GMLFunctionFlags.Stub)]
+		[GMLFunction("window_get_colour", GMLFunctionFlags.Stub)]
 		public static object? window_get_color(object?[] args)
 		{
-			DebugLog.LogWarning("window_get_color not implemented");
 			return null;
 		}
 
@@ -801,11 +797,10 @@ namespace OpenGM.VirtualMachine.BuiltInFunctions
 			return null;
 		}
 
-		[GMLFunction("draw_circle_color")]
-		[GMLFunction("draw_circle_colour")]
+		[GMLFunction("draw_circle_color", GMLFunctionFlags.Stub)]
+		[GMLFunction("draw_circle_colour", GMLFunctionFlags.Stub)]
 		public static object? draw_circle_color(object?[] args)
 		{
-			DebugLog.LogWarning("draw_circle_color not implemented");
 			return null;
 		}
 
@@ -848,12 +843,12 @@ namespace OpenGM.VirtualMachine.BuiltInFunctions
 		// draw_vertex_texture_color
 		// draw_vertex_texture_colour
 
-		[GMLFunction("sprite_get_uvs")]
+		[GMLFunction("sprite_get_uvs", GMLFunctionFlags.Stub)]
 		public static object? sprite_get_uvs(object?[] args)
 		{
 			var spr = args[0].Conv<int>();
 			var subimg = args[0].Conv<int>();
-			DebugLog.LogWarning("sprite_get_uvs not implemented.");
+
 			return new int[8];
 		}
 
@@ -861,12 +856,12 @@ namespace OpenGM.VirtualMachine.BuiltInFunctions
 		// font_get_info
 		// font_cache_glyph
 
-		[GMLFunction("sprite_get_texture")]
+		[GMLFunction("sprite_get_texture", GMLFunctionFlags.Stub)]
 		public static object? sprite_get_texture(object?[] args)
 		{
 			var spr = args[0].Conv<int>();
 			var subimg = args[0].Conv<int>();
-			DebugLog.LogWarning("sprite_get_texture not implemented.");
+
 			return 0;
 		}
 
@@ -1056,11 +1051,10 @@ namespace OpenGM.VirtualMachine.BuiltInFunctions
 			return null;
 		}
 
-		[GMLFunction("draw_text_transformed_color")]
-		[GMLFunction("draw_text_transformed_colour")]
+		[GMLFunction("draw_text_transformed_color", GMLFunctionFlags.Stub)]
+		[GMLFunction("draw_text_transformed_colour", GMLFunctionFlags.Stub)]
 		public static object? draw_text_transformed_colour(object?[] args)
 		{
-			DebugLog.LogWarning("draw_text_transformed_color not implemented");
 			return null;
 		}
 
@@ -1384,10 +1378,9 @@ namespace OpenGM.VirtualMachine.BuiltInFunctions
 			return SurfaceManager.GetSurfaceHeight(surface_id);
 		}
 
-		[GMLFunction("surface_get_texture")]
+		[GMLFunction("surface_get_texture", GMLFunctionFlags.Stub)]
 		public static object? surface_get_texture(object?[] args)
 		{
-			DebugLog.LogWarning("surface_get_texture not implemented.");
 			return -1;
 		}
 
@@ -1453,10 +1446,9 @@ namespace OpenGM.VirtualMachine.BuiltInFunctions
 		// draw_surface_part_ext
 		// draw_surface_general
 
-		[GMLFunction("draw_surface_tiled")]
+		[GMLFunction("draw_surface_tiled", GMLFunctionFlags.Stub)]
 		public static object? draw_surface_tiled(object?[] args)
 		{
-			DebugLog.LogWarning("draw_surface_tiled not implemented");
 			return null;
 		}
 
@@ -1490,7 +1482,7 @@ namespace OpenGM.VirtualMachine.BuiltInFunctions
 			return r | g << 8 | b << 16 | a << 24;
 		}
 
-		[GMLFunction("surface_copy")]
+		[GMLFunction("surface_copy", GMLFunctionFlags.Stub)]
 		public static object? surface_copy(object?[] args)
 		{
 			var destination = args[0].Conv<int>();
@@ -1498,19 +1490,15 @@ namespace OpenGM.VirtualMachine.BuiltInFunctions
 			var y = args[2].Conv<int>();
 			var source = args[3].Conv<int>();
 
-			DebugLog.LogWarning("surface_copy not implemented");
-
 			return null;
 		}
 
 		// surface_copy_part
 		
-		[GMLFunction("application_surface_draw_enable")]
+		[GMLFunction("application_surface_draw_enable", GMLFunctionFlags.Stub)]
 		public static object? application_surface_draw_enable(object?[] args)
 		{
 			var enabled = args[0].Conv<bool>();
-
-			DebugLog.LogWarning("application_surface_draw_enable not implemented");
 
 			return null;
 		}

--- a/OpenGM/VirtualMachine/BuiltInFunctions/LayerFunctions.cs
+++ b/OpenGM/VirtualMachine/BuiltInFunctions/LayerFunctions.cs
@@ -356,16 +356,13 @@ namespace OpenGM.VirtualMachine.BuiltInFunctions
 
 		// layer_element_move
 
-		[GMLFunction("layer_force_draw_depth")]
+		[GMLFunction("layer_force_draw_depth", GMLFunctionFlags.Stub)]
 		public static object? layer_force_draw_depth(object?[] args)
 		{
 			var force = args[0].Conv<bool>();
 			var depth = args[1].Conv<int>();
-			//Debug.Log($"layer_force_draw_depth force:{force} depth:{depth}");
 
 			// not implementing yet because uhhhhhhhhhhhhhhhhhhh
-
-			DebugLog.LogWarning("layer_force_draw_depth not implemented.");
 
 			return null;
 		}
@@ -718,13 +715,12 @@ namespace OpenGM.VirtualMachine.BuiltInFunctions
 			return null;
 		}
 
-		[GMLFunction("layer_sprite_change")]
+		[GMLFunction("layer_sprite_change", GMLFunctionFlags.Stub)]
 		public static object? layer_sprite_change(object?[] args)
 		{
 			var element_id = args[0].Conv<int>();
 			var sprite_id = args[0].Conv<int>();
 
-			DebugLog.LogWarning("layer_sprite_change not implemented.");
 			return null;
 		}
 

--- a/OpenGM/VirtualMachine/BuiltInFunctions/MathFunctions.cs
+++ b/OpenGM/VirtualMachine/BuiltInFunctions/MathFunctions.cs
@@ -147,7 +147,7 @@ public static class MathFunctions
 	// array_insert
 	// array_delete
 
-	[GMLFunction("array_sort")]
+	[GMLFunction("array_sort", GMLFunctionFlags.Stub)]
 	public static object? array_sort(object?[] args)
 	{
 		var variable = args[0].Conv<IList>();
@@ -172,8 +172,7 @@ public static class MathFunctions
 			 *  >= 1	: current element goes after next element
 			 */
 		}
-
-		DebugLog.LogWarning("array_sort is not implemented");
+		
 		return null;
 	}
 

--- a/OpenGM/VirtualMachine/BuiltInFunctions/ParticlesFunctions.cs
+++ b/OpenGM/VirtualMachine/BuiltInFunctions/ParticlesFunctions.cs
@@ -162,12 +162,11 @@ namespace OpenGM.VirtualMachine.BuiltInFunctions
 			return ParticleManager.ParticleSystemCreate();
 		}
 
-		[GMLFunction("part_system_destroy")]
+		[GMLFunction("part_system_destroy", GMLFunctionFlags.Stub)]
 		public static object? part_system_destroy(object?[] args)
 		{
 			//var ind = args[0].Conv<int>();
 
-			DebugLog.LogWarning("part_system_destroy not implemented.");
 			return null;
 		}
 
@@ -200,12 +199,11 @@ namespace OpenGM.VirtualMachine.BuiltInFunctions
 			return null;
 		}
 
-		[GMLFunction("part_system_drawit")]
+		[GMLFunction("part_system_drawit", GMLFunctionFlags.Stub)]
 		public static object? part_system_drawit(object?[] args)
 		{
 			//var ind = args[0].Conv<int>();
 
-			DebugLog.LogWarning("part_system_drawit not implemented");
 			return null;
 		}
 
@@ -227,12 +225,11 @@ namespace OpenGM.VirtualMachine.BuiltInFunctions
 
 		// part_emitter_destroy
 
-		[GMLFunction("part_emitter_destroy_all")]
+		[GMLFunction("part_emitter_destroy_all", GMLFunctionFlags.Stub)]
 		public static object? part_emitter_destroy_all(object?[] args)
 		{
 			//var ps = args[0].Conv<int>();
 
-			DebugLog.LogWarning("part_emitter_destroy_all not implemented");
 			return null;
 		}
 


### PR DESCRIPTION
This PR adds:
- A new log type, `LogType.Verbose`.
- A `GMLFunctionFlags` enum type which can be passed to `GMLFunction`.
- A `GMLFunctionFlags.Stub` value which logs a notice whenever the function is called.
- Additional metrics for which registered GML functions are implemented and which are stubs.

A few log messages were also changed to be more consistent, but that's about it.