### PR TITLE
Normalizing GamePath (treating as a file)

### DIFF
--- a/OpenGM/Entry.cs
+++ b/OpenGM/Entry.cs
@@ -47,11 +47,11 @@ internal class Entry
             }
         }
 
-        GamePath = Path.GetFullPath(path);
+        path = Path.GetFullPath(path);
+        GamePath = File.Exists(path) ? path : Path.Combine(path, "data.win");
         DebugLog.Log($"GamePath: {GamePath}");
 
-        var dataWin = File.Exists(path) ? path : Path.Combine(path, "data.win");
-        LoadGame(dataWin, passedArgs);
+        LoadGame(GamePath, passedArgs);
 
         return GameFunctions.GameEndReturnCode;
     }

--- a/OpenGM/LoadSave.cs
+++ b/OpenGM/LoadSave.cs
@@ -40,7 +40,7 @@ public static class LoadSave
         }
 
         var savedCurrentDir = Environment.CurrentDirectory;
-        Environment.CurrentDirectory = Entry.GamePath;
+        Environment.CurrentDirectory = GetFilePrePend();
 
         var fullPath = Path.GetFullPath(_pszFileName);
         var currentDirectory = Environment.CurrentDirectory;
@@ -78,7 +78,7 @@ public static class LoadSave
         }
 
         var savedCurrentDir = Environment.CurrentDirectory;
-        Environment.CurrentDirectory = Entry.GamePath;
+        Environment.CurrentDirectory = GetFilePrePend();
 
         var fullPath = Path.GetFullPath(_pszFileName);
         var currentDirectory = Environment.CurrentDirectory;
@@ -95,7 +95,7 @@ public static class LoadSave
             return 0;
         }
 
-        var workingDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!;
+        var workingDirectory = GetFilePrePend();
         if (fullPath.StartsWith(workingDirectory))
         {
             name = "";


### PR DESCRIPTION
**What was happening:**
Environment.CurrentDirectory was being set to Entry.GamePath, which may point directly to data.win instead of the game directory itself. This caused incorrect path resolution when calling:
* GetBundleFileName
* GetSaveFileName

in **GetFilePrePend**, **Entry.GamePath** was treated as a file by the use of **Path.GetDirectoryName** that with a directory returns the parent directory.

As a result, save files and bundled resources paths could resolve to invalid locations.

**What this PR changes:**
Normalize GamePath during startup by forcing it to point to the data.win file.
Replace direct usage of **Entry.GamePath** with **GetFilePrePend** in these methods:
* GetBundleFileName
* GetSaveFileName

Closes #84